### PR TITLE
Disable gatekeeper

### DIFF
--- a/ackee-xcode.pkr.hcl
+++ b/ackee-xcode.pkr.hcl
@@ -116,6 +116,7 @@ build {
         inline = [
             "source ~/.zprofile",
             "brew install --cask https://raw.githubusercontent.com/Homebrew/homebrew-cask/673bf36ef0b434bc0f1b879ac055ecabff1edcac/Casks/flutter.rb",
+            "sudo spctl --master-disable",
         ]
     }
 


### PR DESCRIPTION
Old flutter version we use has some old dependency that requires gatekeeper to be disabled. With the gatekeeper still on it hangs on some warning alert.